### PR TITLE
parameratized contracts, arguments, and networking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,12 @@ deploy :; @./scripts/deploy.sh
 
 # mainnet
 deploy-mainnet: export ETH_RPC_URL = $(call network,mainnet)
+deploy-mainnet: export NETWORK=mainnet
 deploy-mainnet: check-api-key deploy
 
 # rinkeby
 deploy-rinkeby: export ETH_RPC_URL = $(call network,rinkeby)
+deploy-rinkeby: export NETWORK=rinkeby
 deploy-rinkeby: check-api-key deploy
 
 # verify on Etherscan

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ make test
 ## Deploying
 
 Contracts can be deployed via the `make deploy` command. Addresses are automatically
-written in a name-address json file stored under `out/addresses.json`.
+written in a name-address json file stored under `out/addresses.json`. Additionally, you can specify a specific network with `make deploy-rinkeby` or `make deploy-mainnet`. You can choose which contract you want to deploy, by adding it as a variable, like so:
+
+```bash
+make deploy-rinkeby CONTRACT=Greeter 
+```
 
 We recommend testing your deployments and provide an example under [`scripts/test-deploy.sh`](./scripts/test-deploy.sh)
 which will launch a local testnet, deploy the contracts, and do some sanity checks.
@@ -70,6 +74,27 @@ ETHERSCAN_API_KEY=<api-key> contract_address=<address> network_name=<mainnet|rin
 
 Check out the [dapp documentation](https://github.com/dapphub/dapptools/tree/master/src/dapp#dapp-verify-contract) to see how
 verifying contracts work with DappTools.
+
+## Adding contracts 
+
+If you want to add your own contract to this template, you need to update the following to make it work with the deploy scripts, you'll need to:
+1. Add the new contract to the `src` folder.
+2. Add any constructor arguments it'll want to the `helper-config.sh` file. 
+3. When you deploy, use `make deploy-rinkeby CONTRACT=<contract-name>`
+
+
+## Adding networks 
+
+To add new networks, simply add a new section in the `Makefile` like so 
+
+```bash
+# kovan
+deploy-kovan: export ETH_RPC_URL = $(call network,kovan)
+deploy-kovan: export NETWORK=kovan
+deploy-kovan: check-api-key deploy
+```
+
+And optionally add parameters to the `helper-config.sh` file. 
 
 ## Installing the toolkit
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -60,7 +60,7 @@ deploy() {
 	ARGS=${@:2}
 
 	# find file path
-	CONTRACT_PATH=$(find . -name $NAME.sol)
+	CONTRACT_PATH=$(find ./src -name $NAME.sol)
 	CONTRACT_PATH=${CONTRACT_PATH:2}
 
 	# select the filename and the contract in it

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,6 +5,12 @@ set -eo pipefail
 # import the deployment helpers
 . $(dirname $0)/common.sh
 
-# Deploy.
-GreeterAddr=$(deploy Greeter)
-log "Greeter deployed at:" $GreeterAddr
+# import config with arguments based on contract and network
+. $(dirname $0)/helper-config.sh
+
+# Deploy 
+# Contract will be counter unless overriden on the command line
+: ${CONTRACT:=Greeter}
+echo "Deploying $CONTRACT to $NETWORK with arguments: $arguments"
+Addr=$(deploy $CONTRACT $arguments)
+log "$CONTRACT deployed at:" $Addr

--- a/scripts/helper-config.sh
+++ b/scripts/helper-config.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Defaults
+# Add your defaults here
+# For example:
+# address=0x01be23585060835e02b77ef475b0cc51aa1e0709
+
+# Add your contract arguments default here
+arguments=""
+
+if [ "$NETWORK" = "rinkeby" ]
+then 
+    : # Add arguments only for rinkeby here!
+    # like: 
+    # address=0x01be23585060835e02b77ef475b0cc51aa1e0709
+elif [ "$NETWORK" = "mainnet" ]
+then 
+    : # Add arguments only for mainnet here!
+    # like: 
+    # address=0x01be23585060835e02b77ef475b0cc51aa1e0709
+fi
+
+if [ "$CONTRACT" = "Greeter" ]
+then 
+    : # Add conditional arguments here for contracts
+    # arguments=$interval
+fi 


### PR DESCRIPTION
Hi! I've made a few changes, outlined in the changelog and readme: 

## 4.3.2
* Contracts now must be in the `src` folder, as the `find` command in `common.sh` now looks only in the `src` folder. This is to improve on naming conflicts with imported packages. 
* Added a `helper-config.sh` for parameratizing arguments for different contracts based on the network you're on.
* Changed `deploy.sh` to be parameratized for contracts and arguments. Adding a `CONTRACT=<contractname>` in the command line will switch the contract. Additionally, if you want arguments of that contract to be added correctly, you have to add them to `helper-config.sh`. 
* Added network exporting in the makefile so the helper config can tell what network you're on. 

I found these tweaks a lot easier to make bigger projects with dependencies. Let me know if you like! I'm a bit of a Makefile noob, so if I did some stuff that wasn't best practice, let me know!