### PR TITLE
Update .gitignore preventing `.env` push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 cache/
 out/
+
+.env


### PR DESCRIPTION
Probably it won't happen because as far as I know, foundry does not support it, but devs could use this template in connection with other tools like `hardhat` that use `.env` and it's not a bad practice to prevent this file to be pushed to the repo.

It could be useful to add more files/folder to `.gitignore`, it would not hurt to ban things like `node_modules` and similar