### PR TITLE
notation for profiles has been deprecated

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,2 +1,2 @@
-[ci]
+[profile.ci]
 fuzz-runs = 10_000


### PR DESCRIPTION
avoid warning:

warning: Unknown section [ci] found in foundry.toml. This notation for profiles has been deprecated and may result in the profile not being registered in future versions. Please use [profile.default] instead or run `forge config --fix`.